### PR TITLE
Refactor MapToolbar for improved structure and styling

### DIFF
--- a/client/src/components/Map/MapToolbar.jsx
+++ b/client/src/components/Map/MapToolbar.jsx
@@ -1,23 +1,22 @@
 import React from 'react';
-import { Box, Button, Typography } from '@mui/material';
+import { Button, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import AddLocationAltIcon from '@mui/icons-material/AddLocationAlt';
 import CloseIcon from '@mui/icons-material/Close';
 
 import { useAppStore } from '../../stores/useAppStore';
 
-const ToolbarWrap = styled(Box)({
+const toolbarPosition = {
   position: 'absolute',
   top: 12,
   left: '50%',
   transform: 'translateX(-50%)',
   zIndex: 2,
-  pointerEvents: 'none',
   maxWidth: 'calc(100% - 24px)',
-});
+};
 
-const Bar = styled(Box)(({ theme }) => ({
-  pointerEvents: 'auto',
+const PlacementBar = styled('div')(({ theme }) => ({
+  ...toolbarPosition,
   display: 'flex',
   alignItems: 'center',
   gap: theme.spacing(1.5),
@@ -46,52 +45,51 @@ const MapToolbar = ({
     onAddPin();
   };
 
+  if (!placementMode) {
+    return (
+      <Button
+        variant="contained"
+        color="primary"
+        size="small"
+        startIcon={<AddLocationAltIcon />}
+        onClick={handleAddClick}
+        disabled={isLocatingForPin}
+        sx={toolbarPosition}
+      >
+        {isLocatingForPin ? 'Finding you…' : 'Add spot'}
+      </Button>
+    );
+  }
+
   return (
-    <ToolbarWrap>
-      <Bar>
-        {placementMode ? (
-          <>
-            <Typography
-              variant="body2"
-              color="text.secondary"
-              sx={{ maxWidth: { xs: 220, sm: 400 } }}
-            >
-              {placementDesktop
-                ? 'Click on the map to place your spot.'
-                : 'Drag the pin or tap the map where this spot should go.'}
-            </Typography>
-            {!placementDesktop ? (
-              <Button
-                size="small"
-                variant="contained"
-                onClick={onConfirmPlacement}
-              >
-                Place here
-              </Button>
-            ) : null}
-            <Button
-              size="small"
-              color="inherit"
-              startIcon={<CloseIcon />}
-              onClick={onCancelAdd}
-            >
-              Cancel
-            </Button>
-          </>
-        ) : (
-          <Button
-            variant="contained"
-            color="primary"
-            size="small"
-            startIcon={<AddLocationAltIcon />}
-            onClick={handleAddClick}
-            disabled={isLocatingForPin}
-          >
-            {isLocatingForPin ? 'Finding you…' : 'Add spot'}
-          </Button>
-        )}
-      </Bar>
-    </ToolbarWrap>
+    <PlacementBar>
+      <Typography
+        variant="body2"
+        color="text.secondary"
+        sx={{ maxWidth: { xs: 220, sm: 400 } }}
+      >
+        {placementDesktop
+          ? 'Click on the map to place your spot.'
+          : 'Drag the pin or tap the map where this spot should go.'}
+      </Typography>
+      {!placementDesktop ? (
+        <Button
+          size="small"
+          variant="contained"
+          onClick={onConfirmPlacement}
+        >
+          Place here
+        </Button>
+      ) : null}
+      <Button
+        size="small"
+        color="inherit"
+        startIcon={<CloseIcon />}
+        onClick={onCancelAdd}
+      >
+        Cancel
+      </Button>
+    </PlacementBar>
   );
 };
 


### PR DESCRIPTION
This pull request refactors the `MapToolbar` component to simplify its structure and improve clarity. The main changes include removing unnecessary wrapper components, consolidating conditional rendering logic, and updating styling to use a more straightforward approach.

Component structure simplification:

* Removed the `ToolbarWrap` and `Bar` styled components, replacing them with a single `PlacementBar` styled div for toolbar placement and styling. This reduces component nesting and simplifies the code.
* Moved the conditional rendering logic out of the JSX tree, so that the "Add spot" button is only rendered when `placementMode` is false, and the placement controls are rendered otherwise. This makes the component logic easier to follow. [[1]](diffhunk://#diff-7173aa8b01dbf47e07d525752d10124eaf27260f0b2d727f2d65b1d2e8b041e9R48-R65) [[2]](diffhunk://#diff-7173aa8b01dbf47e07d525752d10124eaf27260f0b2d727f2d65b1d2e8b041e9L80-R92)

Styling improvements:

* Centralized toolbar positioning styles in the `toolbarPosition` object and applied them directly to the button when `placementMode` is false, ensuring consistent placement.